### PR TITLE
#11 Fix revdiff flow after close — execute annotations and loop

### DIFF
--- a/docs/ai/11-revdiff-flow-after-close/11-revdiff-flow-after-close-plan.md
+++ b/docs/ai/11-revdiff-flow-after-close/11-revdiff-flow-after-close-plan.md
@@ -1,0 +1,167 @@
+# Fix revdiff flow after close — implementation plan
+
+**Task:** docs/ai/11-revdiff-flow-after-close/11-revdiff-flow-after-close-task.md
+**Complexity:** simple
+**Mode:** sub-agents
+**Parallel:** true
+
+## Design decisions
+
+### DD-1: Inline per skill, no shared reference doc
+
+**Decision:** Rewrite the "Review via revdiff" bullet inline in each of the three SKILL.md files. Skip `lib/revdiff-protocol.md` and any per-skill `reference/revdiff-protocol.md`.
+**Rationale:** A shared doc would reintroduce the root cause — the model reads "call /revdiff" as the terminal action whenever the reference site repeats the same positional bug. The architect confirmed this (`docs/ai/11-revdiff-flow-after-close/11-revdiff-flow-after-close-task.md`, Patterns section) and the user accepted it at /task time. Each bullet already differs in args and semantics; factoring out saves no real duplication.
+**Alternative:** Shared `lib/revdiff-protocol.md` referenced from each bullet. Rejected — indirection at best, recreated bug at worst.
+
+### DD-2: /do applies annotations inline in the orchestrator — no new agent dispatch
+
+**Decision:** When `/do` Phase 7 picks "Review via revdiff" and revdiff returns non-empty annotations, the /do orchestrator reads the annotations, applies any described code changes directly, then appends the annotation text to the report. No Agent tool call spawned for annotation application.
+**Rationale:** Matches the existing inline report-append pattern that `/do` Phase 7 already runs (`skills/do/SKILL.md:290` today — the orchestrator appends without dispatch). Annotation scope is small; dispatching a fresh agent adds latency and context-copy overhead. The user confirmed this at /task time.
+**Alternative:** Dispatch `skills/do/agents/task-executor.md` with the annotation text as a fresh task. Rejected — heavier, loses the conversational context of the revdiff session.
+
+### DD-3: Detect "annotations returned" via empty-vs-non-empty Skill return
+
+**Decision:** Treat the `/revdiff` Skill tool return as text. Non-empty return means annotations arrived → apply/execute. Empty return means the user quit without annotating → skip apply.
+**Rationale:** Simple, forward-compatible, and decouples the SKILL.md from revdiff's internal schema. The `README.md:319-321` Interactive review section already describes revdiff's behavior as "returns structured annotations on quit" without pinning format. The user confirmed this at /task time.
+**Alternative:** Pin a JSON schema in the SKILL.md. Rejected — couples yoke to a specific revdiff version and adds failure modes as revdiff evolves.
+
+### DD-4: Loop-back phrasing — byte-identical string across all three files
+
+**Decision:** Each rewritten bullet ends with the exact phrase: `Return to the "Offer 3 options" step above.` The same phrase appears in the install-hint fallback branch of each bullet.
+**Rationale:** Matches `/fix` Phase 7's destination-naming pattern (`skills/fix/SKILL.md:248`: "go back to Phase 1 (SLUG is preserved)"), which names where to go. Byte-identical phrasing across all three files lets a Task 4 grep verify consistency and removes the ambiguity of the current "Loop back to the start" that the prior PR #1 failed to resolve (`docs/ai/1-replace-plannotator-with-revdiff/1-replace-plannotator-with-revdiff-review.md:99`).
+**Alternative:** Per-skill phrasings (e.g. "re-present the AskUserQuestion", "restart the loop"). Rejected — grep cannot enforce consistency; reintroduces ambiguity.
+
+### DD-5: Continuation obligation stated BEFORE the Skill call
+
+**Decision:** Each rewritten bullet opens with the literal phrase `After revdiff closes, continue with the following steps:` (or an equivalent, grep-discoverable) right before the numbered step list, with the /revdiff Skill call sitting as a middle step — not the last action.
+**Rationale:** Root-cause fix (see the task file's Context section). The prior PR #1 fix (`1e18e1b`) sharpened wording but kept the Skill call last in the bullet, so the model kept reading the tool call as terminal. Announcing continuation up front makes the post-close steps an explicit obligation.
+**Alternative:** Leave the announcement implicit; rely on numbered-step structure alone. Rejected — numbered steps alone failed to fix the bug during testing of PR #1's clarified wording.
+
+### DD-6: Three independent commits, one per skill file
+
+**Decision:** Tasks 1, 2, and 3 each produce a separate commit for their SKILL.md file. Task 4 (Validation) produces no commit.
+**Rationale:** Each skill's change reverts independently; `git bisect` across the three skills stays precise; the commit log reads one bullet rewrite per commit.
+**Alternative:** One combined commit for all three files. Rejected — loses revert granularity and complicates diff review (3 nearly identical structural changes in one diff).
+
+## Tasks
+
+### Task 1: Rewrite `skills/task/SKILL.md` "Review via revdiff" bullet
+
+- **Files:** `skills/task/SKILL.md:272` (edit)
+- **Depends on:** none
+- **Scope:** S
+- **What:** Replace the single-line "Review via revdiff" bullet at line 272 with a 4-step inline structure that states the continuation obligation before the `/revdiff` Skill call, handles empty vs non-empty return, and loops back using the canonical phrase.
+- **How:**
+  1. Read `skills/task/SKILL.md:260-273` for the surrounding Phase 6 Complete loop context.
+  2. Replace the entire line at position 272 (the bullet `- **Review via revdiff:** call the Skill tool with /revdiff and the argument --only docs/ai/<task-slug>/<task-slug>-task.md. Apply the returned annotations, overwrite the file. Loop back to the start. If the plugin is missing — print ... then loop back to the start.`) with the new bullet:
+     ```
+     - **Review via revdiff:** After revdiff closes, continue with the following steps:
+       1. Call the Skill tool with `/revdiff` and the argument `--only docs/ai/<task-slug>/<task-slug>-task.md`.
+       2. If the Skill return is non-empty, apply the returned annotations to the task file and overwrite `docs/ai/<task-slug>/<task-slug>-task.md`. If the return is empty, skip this step.
+       3. Return to the "Offer 3 options" step above.
+       If the plugin is missing — print `Install the revdiff plugin:` followed by `  /plugin marketplace add umputun/revdiff` and `  /plugin install revdiff@umputun-revdiff`, then return to the "Offer 3 options" step above.
+     ```
+  3. Leave every other line untouched. Verify via `git diff --stat` that only `skills/task/SKILL.md` changed.
+  4. Commit: `#11 fix(11-revdiff-flow-after-close): restructure task revdiff bullet to execute annotations after close` (per `${CLAUDE_PLUGIN_ROOT}/skills/gca/reference/commit-convention.md`).
+- **Context:** `skills/task/SKILL.md:254-273` (surrounding Phase 6 Complete loop), `skills/fix/SKILL.md:246-250` (destination-naming reference pattern), `docs/ai/11-revdiff-flow-after-close/11-revdiff-flow-after-close-task.md` (Requirement 1, Constraints).
+- **Verify:** `head -1 skills/task/SKILL.md` → `---`; `grep -n "After revdiff closes, continue with the following steps:" skills/task/SKILL.md` → one match at the new bullet; `grep -n "Return to the \"Offer 3 options\" step above." skills/task/SKILL.md` → at least two matches (main path + install-hint fallback); `git diff --stat HEAD~1 HEAD` → only `skills/task/SKILL.md` touched.
+
+### Task 2: Rewrite `skills/plan/SKILL.md` "Review via revdiff" bullet
+
+- **Files:** `skills/plan/SKILL.md:298` (edit)
+- **Depends on:** none
+- **Scope:** S
+- **What:** Replace the single-line "Review via revdiff" bullet at line 298 with the same 4-step inline structure as Task 1, swapping in plan-file args.
+- **How:**
+  1. Read `skills/plan/SKILL.md:287-299` for the surrounding Phase 8 Complete loop context.
+  2. Replace the entire bullet at line 298 with:
+     ```
+     - **Review via revdiff:** After revdiff closes, continue with the following steps:
+       1. Call the Skill tool with `/revdiff` and the argument `--only docs/ai/<TASK_SLUG>/<TASK_SLUG>-plan.md`.
+       2. If the Skill return is non-empty, apply the returned annotations to the plan file and overwrite `docs/ai/<TASK_SLUG>/<TASK_SLUG>-plan.md`. If the return is empty, skip this step.
+       3. Return to the "Offer 3 options" step above.
+       If the plugin is missing — print `Install the revdiff plugin:` followed by `  /plugin marketplace add umputun/revdiff` and `  /plugin install revdiff@umputun-revdiff`, then return to the "Offer 3 options" step above.
+     ```
+  3. Leave every other line untouched. Verify via `git diff --stat`.
+  4. Commit: `#11 fix(11-revdiff-flow-after-close): restructure plan revdiff bullet to execute annotations after close`.
+- **Context:** `skills/plan/SKILL.md:280-299` (surrounding Phase 8 Complete loop), `docs/ai/11-revdiff-flow-after-close/11-revdiff-flow-after-close-task.md` (Requirement 2, Constraints).
+- **Verify:** `head -1 skills/plan/SKILL.md` → `---`; `grep -n "After revdiff closes, continue with the following steps:" skills/plan/SKILL.md` → one match; `grep -n "Return to the \"Offer 3 options\" step above." skills/plan/SKILL.md` → at least two matches; `git diff --stat HEAD~1 HEAD` → only `skills/plan/SKILL.md` touched.
+
+### Task 3: Rewrite `skills/do/SKILL.md` "Review via revdiff" bullet
+
+- **Files:** `skills/do/SKILL.md:290` (edit)
+- **Depends on:** none
+- **Scope:** M
+- **What:** Replace the dense prose bullet at line 290 with the 4-step skeleton. Step 2 (annotation handling) carries a nested sub-list that preserves every semantic from PR #1: base-resolution cascade, inline orchestrator code edits for annotations describing code changes (skip for prose-only annotations), report append under `## Review notes`, `.gitignore` check, auto-commit. Install-hint fallback preserved with canonical loop-back phrasing.
+- **How:**
+  1. Read `skills/do/SKILL.md:279-291` for the surrounding Phase 7 Complete section.
+  2. Replace the entire bullet at line 290 with:
+     ```
+     - **Review via revdiff:** After revdiff closes, continue with the following steps:
+       1. Resolve the default base via the cascade `git symbolic-ref refs/remotes/origin/HEAD` → `origin/main` → `origin/master` → fallback `main` (see `skills/gp/agents/git-pre-checker.md:43-54`). Call the Skill tool with `/revdiff` and the argument `<default-base>...HEAD`.
+       2. If the Skill return is non-empty:
+          - If the annotations describe code changes, apply those code changes inline (orchestrator edits — do not dispatch a sub-agent). If the annotations are prose-only, skip the code-edit step.
+          - Append the full annotation text to `docs/ai/<SLUG>/<SLUG>-report.md`: if a `## Review notes` heading already exists in the file, append under the existing heading; otherwise create the heading and append under it.
+          - Check `.gitignore` for `docs/ai/` (same as Phase 6c). If ignored, skip the auto-commit. Otherwise, run `git add docs/ai/<SLUG>/<SLUG>-report.md && git commit -m "TICKET docs(SLUG): append review notes"` (per `${CLAUDE_PLUGIN_ROOT}/skills/gca/reference/commit-convention.md`).
+          If the Skill return is empty, skip this entire step.
+       3. Return to the "Offer 3 options" step above.
+       If the plugin is missing — print `Install the revdiff plugin:` followed by `  /plugin marketplace add umputun/revdiff` and `  /plugin install revdiff@umputun-revdiff`, then return to the "Offer 3 options" step above.
+     ```
+  3. Leave every other line untouched. Verify via `git diff --stat`.
+  4. Commit: `#11 fix(11-revdiff-flow-after-close): restructure do revdiff bullet to execute annotations after close`.
+- **Context:** `skills/do/SKILL.md:275-291` (surrounding Phase 7 Complete + Phase 6c gitignore pattern), `skills/gp/agents/git-pre-checker.md:43-54` (default-base cascade), `docs/ai/11-revdiff-flow-after-close/11-revdiff-flow-after-close-task.md` (Requirement 3, Constraints).
+- **Verify:** `head -1 skills/do/SKILL.md` → `---`; `grep -n "After revdiff closes, continue with the following steps:" skills/do/SKILL.md` → one match; `grep -n "Return to the \"Offer 3 options\" step above." skills/do/SKILL.md` → at least two matches; `grep -n "append review notes" skills/do/SKILL.md` → one match (commit-message string preserved); `grep -n "skills/gp/agents/git-pre-checker.md:43-54" skills/do/SKILL.md` → one match (cascade reference preserved); `git diff --stat HEAD~1 HEAD` → only `skills/do/SKILL.md` touched.
+
+### Task 4: Validation
+
+- **Files:** none modified
+- **Depends on:** Task 1, Task 2, Task 3
+- **Scope:** S
+- **What:** Run the full post-edit validation suite. Confirm all three rewrites parse cleanly, stay byte-consistent on the shared phrases, preserve PR #1 semantics, and pass repo-level format checks.
+- **How:**
+  1. JSON parse: `python3 -c "import json; json.load(open('.claude-plugin/plugin.json')); json.load(open('.claude-plugin/marketplace.json')); print('OK')"`.
+  2. YAML frontmatter preserved: `head -1 skills/task/SKILL.md skills/plan/SKILL.md skills/do/SKILL.md` — each file's first line must read `---`.
+  3. Continuation obligation placed before the Skill call in all three files: `grep -n "After revdiff closes, continue with the following steps:" skills/task/SKILL.md skills/plan/SKILL.md skills/do/SKILL.md` — exactly 3 matches, one per file. Each match's line number must fall strictly below the line number of the first `/revdiff` Skill call reference in the same bullet.
+  4. Loop-back phrase byte-identical across all three files: `grep -cn "Return to the \"Offer 3 options\" step above." skills/task/SKILL.md skills/plan/SKILL.md skills/do/SKILL.md` — each file shows ≥ 2 matches (main path + install-hint fallback).
+  5. Empty-return skip branch present in all three files: `grep -c "If the Skill return is empty" skills/task/SKILL.md skills/plan/SKILL.md skills/do/SKILL.md` — each file shows ≥ 1 match (phrasing may read "If the return is empty" for task/plan or "If the Skill return is empty" for do; accept either variant).
+  6. `/do` Phase 7 semantics from PR #1 intact: `grep -n "append review notes" skills/do/SKILL.md` — 1 match (commit message preserved); `grep -n "## Review notes" skills/do/SKILL.md` — ≥ 1 match (heading semantics preserved); `grep -n "skills/gp/agents/git-pre-checker.md:43-54" skills/do/SKILL.md` — 1 match (cascade reference preserved).
+  7. Prettier format check: `pnpm run format:check` — no new failures on the three edited files.
+- **Context:** none (pure verification).
+- **Verify:** every command in steps 1–7 exits 0 with the expected outputs above; `pnpm run format:check` reports no new failures.
+
+## Execution
+
+- **Mode:** sub-agents
+- **Parallel:** true
+- **Reasoning:** The three independent single-file bullet rewrites share no files or state; a final validation barrier checks cross-file byte consistency on the pre-agreed phrases.
+- **Order:**
+  Group 1 (parallel): Task 1, Task 2, Task 3
+  ─── barrier ───
+  Group 2 (sequential): Task 4
+
+## Verification
+
+- **Manual — `/yoke:task` with annotations:** run `/yoke:task <ticket>` → reach Phase 6 Complete → pick "Review via revdiff" → add annotations in revdiff → quit → task file overwritten with annotations applied → `AskUserQuestion` with 3 options reappears.
+- **Manual — `/yoke:task` without annotations:** same as above, but quit revdiff without adding annotations → task file unchanged → `AskUserQuestion` with 3 options reappears.
+- **Manual — `/yoke:plan` with annotations:** run `/yoke:plan <task-path>` → reach Phase 8 Complete → pick "Review via revdiff" → annotate → quit → plan file overwritten with annotations → `AskUserQuestion` reappears.
+- **Manual — `/yoke:plan` without annotations:** same, quit without annotating → plan file unchanged → `AskUserQuestion` reappears.
+- **Manual — `/yoke:do` with annotations:** run `/yoke:do <plan-path>` → reach Phase 7 Complete → pick "Review via revdiff" → annotate code regions → quit → code changes described in annotations land in the affected files → annotation text appended under `## Review notes` in `docs/ai/<SLUG>/<SLUG>-report.md` → (if `docs/ai/` stays out of `.gitignore`) auto-commit `TICKET docs(SLUG): append review notes` created → `AskUserQuestion` reappears.
+- **Manual — `/yoke:do` without annotations:** same, quit without annotating → no code changes, no report append, no commit → `AskUserQuestion` reappears.
+- **Manual — revdiff plugin missing:** in any of the three skills, pick "Review via revdiff" when `/revdiff` is not installed → install-hint prints → `AskUserQuestion` reappears.
+- **Manual — loop termination:** loop through "Review via revdiff" at least twice, then pick **Finish** → loop exits and the skill reports the file path.
+- **Manual — `docs/ai/` gitignored (`/yoke:do` only):** add `docs/ai/` to local `.gitignore` → `/yoke:do` Phase 7 revdiff path with annotations → report file updated, auto-commit skipped, `AskUserQuestion` reappears.
+- `python3 -c "import json; json.load(open('.claude-plugin/plugin.json')); json.load(open('.claude-plugin/marketplace.json')); print('OK')"` → `OK`.
+- `head -1 skills/task/SKILL.md skills/plan/SKILL.md skills/do/SKILL.md` → each file starts with `---`.
+- `pnpm run format:check` → no new failures.
+
+## Materials
+
+- [GitHub Issue #11](https://github.com/yokeloop/yoke/issues/11)
+- `skills/task/SKILL.md:272` — task bullet
+- `skills/plan/SKILL.md:298` — plan bullet
+- `skills/do/SKILL.md:290` — do bullet
+- `skills/fix/SKILL.md:246-250` — destination-naming loop pattern
+- `skills/gp/agents/git-pre-checker.md:43-54` — default-base cascade used by `/do`
+- `${CLAUDE_PLUGIN_ROOT}/skills/gca/reference/commit-convention.md` — commit-message convention
+- `docs/ai/1-replace-plannotator-with-revdiff/1-replace-plannotator-with-revdiff-review.md` — prior PR review (scope at :60-63, prior attempted fix at :99)
+- `README.md:274-323` — Interactive review (revdiff) section (read-only reference)

--- a/docs/ai/11-revdiff-flow-after-close/11-revdiff-flow-after-close-report.md
+++ b/docs/ai/11-revdiff-flow-after-close/11-revdiff-flow-after-close-report.md
@@ -1,0 +1,64 @@
+# Report: 11-revdiff-flow-after-close
+
+**Plan:** docs/ai/11-revdiff-flow-after-close/11-revdiff-flow-after-close-plan.md
+**Mode:** sub-agents
+**Status:** ✅ complete
+
+## Tasks
+
+| #   | Task                                             | Status  | Commit    | Concerns   |
+| --- | ------------------------------------------------ | ------- | --------- | ---------- |
+| 1   | Rewrite `skills/task/SKILL.md` revdiff bullet    | ✅ DONE | `9d52739` | see below  |
+| 2   | Rewrite `skills/plan/SKILL.md` revdiff bullet    | ✅ DONE | `d4eaa4e` | see below  |
+| 3   | Rewrite `skills/do/SKILL.md` revdiff bullet      | ✅ DONE | `ce99939` | see below  |
+| 4   | Validation barrier                               | ✅ DONE | —         | —          |
+
+## Post-implementation
+
+| Step          | Status   | Commit    |
+| ------------- | -------- | --------- |
+| Polish        | N/A      | —         |
+| Validate      | ✅ pass  | —         |
+| Documentation | N/A      | —         |
+| Format        | ✅ done  | `19a9d21` |
+
+Polish and Documentation are N/A: the change is markdown-only in skill instructions — nothing to simplify in code, and the plan constraints forbid edits to `docs/*.md` and `README.md`.
+
+## Concerns
+
+### Tasks 1, 2, 3 — verification-spec defect (non-blocking)
+
+The plan's per-task Verify step specified `grep -cn "Return to the \"Offer 3 options\" step above."` should return 2 case-sensitive matches per file. The approved bullet text uses `Return` at sentence-start (step 3) and `return` mid-sentence (in the install-hint fallback: "then return to..."). Byte-for-byte implementation of the spec's code fence yields 1 case-sensitive + 1 case-insensitive match (2 matches total under case-insensitive grep). Task 4 used a case-insensitive grep to verify the 2 matches. The loop-back phrase text is present exactly twice in every file as the spec intended; the grep-case quibble is a spec-authoring slip, not an implementation defect.
+
+### Task 3 — prettier re-indentation of fallback lines (resolved)
+
+On post-edit prettier run, the "If the plugin is missing" and (in `/do`) "If the Skill return is empty" lines were re-indented from 2-space/5-space (sibling of numbered steps) to 5-space/7-space (continuation of the preceding list item). This changes the markdown AST nesting but not the text content: each line self-identifies its scope ("If the plugin is missing — print..." / "If the Skill return is empty, skip this entire step"), so the orchestrator reading the SKILL.md picks up the correct semantics regardless of nesting depth. Accepting prettier's authoritative formatting avoids fighting the pre-commit hook. Committed separately as `19a9d21`.
+
+## Validation
+
+```
+python3 plugin.json/marketplace.json parse    ✅ OK
+head -1 skills/{task,plan,do}/SKILL.md        ✅ each file starts with ---
+grep "After revdiff closes, continue..."      ✅ 1 match per file
+grep "Return to the \"Offer 3 options\"..."   ✅ 2 matches per file (case-insensitive)
+grep "If the ... return is empty"             ✅ 1 match per file
+grep "append review notes" (do only)          ✅ 1 match
+grep "## Review notes" (do only)              ✅ 1 match
+grep "skills/gp/agents/git-pre-checker.md:43-54" (do only)  ✅ 1 match
+pnpm run format:check                         ✅ all matched files use Prettier code style
+```
+
+## Changes summary
+
+| File                    | Action   | Description                                                                                                                           |
+| ----------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `skills/task/SKILL.md`  | modified | Line 272 bullet restructured: 4-step inline sequence with continuation obligation before `/revdiff` call; empty-return skip; canonical loop-back phrase. |
+| `skills/plan/SKILL.md`  | modified | Line 298 bullet restructured with the same 4-step template, plan-file args.                                                           |
+| `skills/do/SKILL.md`    | modified | Line 290 bullet restructured with the 4-step skeleton; step 2 carries nested sub-list preserving PR #1 semantics (cascade, report append, gitignore check, auto-commit). |
+
+## Commits
+
+- `9d52739` `#11 fix(11-revdiff-flow-after-close): restructure task revdiff bullet to execute annotations after close`
+- `d4eaa4e` `#11 fix(11-revdiff-flow-after-close): restructure plan revdiff bullet to execute annotations after close`
+- `ce99939` `#11 fix(11-revdiff-flow-after-close): restructure do revdiff bullet to execute annotations after close`
+- `19a9d21` `#11 style(11-revdiff-flow-after-close): apply prettier to revdiff bullets`

--- a/docs/ai/11-revdiff-flow-after-close/11-revdiff-flow-after-close-review.md
+++ b/docs/ai/11-revdiff-flow-after-close/11-revdiff-flow-after-close-review.md
@@ -1,0 +1,109 @@
+# Code Review: 11-revdiff-flow-after-close
+
+## Summary
+
+### Context and goal
+
+Fix a silent-exit bug in the "Review via revdiff" branch of the Complete-phase loop in `/task`, `/plan`, and `/do`. The prior bullet placed the `/revdiff` Skill call as the syntactically last action, causing the model to treat it as terminal and skip the post-close obligations (check annotations → apply/execute → re-present `AskUserQuestion`). This PR restructures each bullet so the continuation obligation appears before the Skill call, with numbered steps guiding the model through call → apply → loop-back, and adds an explicit empty-return skip branch.
+
+### Key code areas for review
+
+1. **`skills/task/SKILL.md:272`** — Phase 6 "Review via revdiff" bullet rewritten as 4-step inline sequence.
+2. **`skills/plan/SKILL.md:298`** — Phase 8 "Review via revdiff" bullet rewritten with the same template.
+3. **`skills/do/SKILL.md:290`** — Phase 7 "Review via revdiff" bullet rewritten; step 2 carries a nested sub-list preserving every PR #1 semantic (base cascade, `## Review notes` append, `.gitignore` check, auto-commit, install-hint fallback).
+4. **`skills/do/SKILL.md:292`** — step 2 leads with the empty-return skip clause for unambiguous scope (review fix).
+
+### Complex decisions
+
+1. **Inline numbered steps, no shared reference doc** (all three bullets)
+   A shared `lib/revdiff-protocol.md` would have reintroduced the root-cause bug at the reference site. Each bullet differs in args and /do has unique sub-steps, so factoring out saves no meaningful duplication.
+
+2. **Continuation obligation stated BEFORE the Skill call** (`skills/task/SKILL.md:272`, `skills/plan/SKILL.md:298`, `skills/do/SKILL.md:290`)
+   The literal phrase `After revdiff closes, continue with the following steps:` opens each bullet. This is the core root-cause fix — the prior PR #1 (`1e18e1b`) clarified the loop-back wording but kept the Skill call last, so the bug persisted. Announcing continuation up front makes post-close steps an explicit obligation.
+
+3. **Byte-identical loop-back phrase across all three files** (`Return to the "Offer 3 options" step above.`)
+   Matches `/fix` Phase 7's destination-naming pattern (`skills/fix/SKILL.md:248`). Byte-identical phrasing enables grep-based consistency checks and removes the ambiguity of the prior "Loop back to the start" wording.
+
+4. **Empty-return skip leads /do step 2** (`skills/do/SKILL.md:292`)
+   Originally written as "If the Skill return is non-empty: ... [sub-bullets] ... If the Skill return is empty, skip this entire step." Prettier re-indented the skip clause as a nested continuation of the last sub-bullet, making the scope ambiguous. Restructured to lead step 2 with "If the Skill return is empty, skip this entire step. Otherwise:" — prettier-safe and structurally unambiguous.
+
+### Questions for the reviewer
+
+1. The verification-spec defect (case-sensitive grep vs capitalized "Return" at sentence-start, lowercase "return" mid-sentence) was handled by switching Task 4 to a case-insensitive grep. Worth updating the plan template to recommend case-insensitive grep for prose-embedded phrases?
+2. `/task` and `/plan` install-hint fallbacks still sit at 5-space indent (continuation of step 3 in the markdown AST). Text self-identification is sufficient, but is there value in a /do-style restructure for consistency?
+3. No version pin on the external revdiff plugin — still open from PR #1 review question 2.
+
+### Risks and impact
+
+- No code paths broken — markdown-only edits to skill instructions.
+- External dependency surface area unchanged — revdiff plugin install-hint fallback preserved verbatim from PR #1.
+- PR #1 `/do` Phase 7 semantics (cascade reference, `## Review notes` heading, gitignore check, auto-commit) are preserved and verified by Task 4 greps.
+
+### Tests and manual checks
+
+**Auto-tests:** none (markdown-only plugin, no tests in the repo).
+
+**Manual scenarios** (per plan Verification section):
+
+1. `/yoke:task <ticket>` → Phase 6 pick "Review via revdiff" → annotate → quit → task file overwritten → `AskUserQuestion` re-appears.
+2. `/yoke:task` → Phase 6 pick "Review via revdiff" → quit without annotating → task file unchanged → `AskUserQuestion` re-appears.
+3. `/yoke:plan <task-path>` → Phase 8 same outcomes for the plan file.
+4. `/yoke:do <plan-path>` → Phase 7 pick "Review via revdiff" → annotate code regions → quit → code changes implemented inline → annotations appended under `## Review notes` → auto-commit `#11 docs(...): append review notes` → `AskUserQuestion` re-appears.
+5. `/yoke:do` → Phase 7 pick "Review via revdiff" → quit without annotating → no code change, no report append, no commit → `AskUserQuestion` re-appears.
+6. Negative — uninstall revdiff → pick "Review via revdiff" → install hint prints → `AskUserQuestion` re-appears without crash.
+7. Loop termination — loop "Review via revdiff" twice, then pick **Finish** → loop exits.
+8. Gitignore negative — add `docs/ai/` to `.gitignore` → `/yoke:do` Phase 7 revdiff with annotations → report updated, auto-commit skipped, `AskUserQuestion` re-appears.
+
+### Out of scope
+
+- `/fix`, `/review`, `/explore`, `/gca`, `/gp`, `/pr`, `/gst`, `/hi`, `/bootstrap` — no revdiff branch, explicitly excluded per Task constraints.
+- `docs/task.md`, `docs/plan.md`, `docs/do.md`, `README.md` — wording remains accurate after the restructure.
+- Historical artifacts under `docs/ai/1-replace-plannotator-with-revdiff/` — untouched.
+- Shared revdiff-protocol reference doc — explicitly rejected in DD-1.
+- Revdiff return-format schema — explicitly rejected in DD-3 (empty-vs-non-empty detection only).
+
+## Commits
+
+| Hash      | Description                                                                                            |
+| --------- | ------------------------------------------------------------------------------------------------------ |
+| `d34616f` | `#11 docs(11-revdiff-flow-after-close): add task definition`                                           |
+| `215f54c` | `#11 docs(11-revdiff-flow-after-close): add implementation plan`                                       |
+| `9d52739` | `#11 fix(11-revdiff-flow-after-close): restructure task revdiff bullet to execute annotations after close` |
+| `d4eaa4e` | `#11 fix(11-revdiff-flow-after-close): restructure plan revdiff bullet to execute annotations after close` |
+| `ce99939` | `#11 fix(11-revdiff-flow-after-close): restructure do revdiff bullet to execute annotations after close`   |
+| `19a9d21` | `#11 style(11-revdiff-flow-after-close): apply prettier to revdiff bullets`                            |
+| `186e49d` | `#11 docs(11-revdiff-flow-after-close): add execution report`                                          |
+| `e34ff9d` | `#11 fix(11-revdiff-flow-after-close): lead do step 2 with empty-return skip for unambiguous scope`    |
+
+## Changed Files
+
+| File                                                             | +/-     | Description                                                                              |
+| ---------------------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------- |
+| `skills/task/SKILL.md`                                           | +5/-1   | Phase 6 "Review via revdiff" bullet restructured to 4-step inline form                   |
+| `skills/plan/SKILL.md`                                           | +5/-1   | Phase 8 "Review via revdiff" bullet restructured to 4-step inline form                   |
+| `skills/do/SKILL.md`                                             | +8/-1   | Phase 7 "Review via revdiff" bullet restructured; step 2 leads with empty-return skip    |
+| `docs/ai/11-revdiff-flow-after-close/*-task.md`                  | +109/-0 | Task definition artifact                                                                 |
+| `docs/ai/11-revdiff-flow-after-close/*-plan.md`                  | +167/-0 | Implementation plan artifact                                                             |
+| `docs/ai/11-revdiff-flow-after-close/*-report.md`                | +64/-0  | Execution report artifact                                                                |
+
+## Issues Found
+
+| Severity  | Score | Category              | File:line                | Description                                                                                                     |
+| --------- | ----- | --------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| Important | 82    | bug (instruction)     | `skills/do/SKILL.md:296` | Empty-return skip clause sits at 7-space indent (continuation of gitignore sub-bullet); scope ambiguous vs step 2 |
+
+## Fixed Issues
+
+| Issue                                                 | Commit    | Description                                                                                  |
+| ----------------------------------------------------- | --------- | -------------------------------------------------------------------------------------------- |
+| Empty-return skip scope ambiguous (`do/SKILL.md:296`) | `e34ff9d` | Restructured step 2 to open with the empty-return skip; prettier-safe and unambiguous |
+
+## Skipped Issues
+
+**All found issues were fixed.**
+
+## Recommendations
+
+- Before merging, run manual scenarios 1–8 above — especially 4 (/do with annotations, the only path exercising both inline code edits and auto-commit) and 6 (plugin-missing fallback).
+- The two pre-existing concerns from the execution report — the case-sensitive grep verification-spec defect and the prettier re-indentation of `/task` and `/plan` install-hint fallbacks — are accepted. Neither blocks the core fix. Consider a follow-up ticket to (a) add a plan-template guidance note on case-insensitive grep for prose-embedded phrases and (b) apply the same step-2-style restructure to `/task` and `/plan` for visual consistency.
+- PR #1 follow-up items remain open: Telegram notification on `/do` Phase 7 install-hint path (question 3 of PR #1 review) and revdiff plugin version pinning (question 2 of PR #1 review).

--- a/docs/ai/11-revdiff-flow-after-close/11-revdiff-flow-after-close-task.md
+++ b/docs/ai/11-revdiff-flow-after-close/11-revdiff-flow-after-close-task.md
@@ -1,0 +1,109 @@
+# Fix revdiff flow after close — execute annotations and re-present AskUserQuestion
+
+**Slug:** 11-revdiff-flow-after-close
+**Ticket:** https://github.com/yokeloop/yoke/issues/11
+**Complexity:** simple
+**Type:** general
+
+## Task
+
+Rewrite the "Review via revdiff" branch in `skills/task/SKILL.md:272`, `skills/plan/SKILL.md:298`, and `skills/do/SKILL.md:290` so post-close obligations (check annotations → apply/execute → re-present AskUserQuestion) appear before the `/revdiff` Skill call, not after it, and so the loop runs until the user picks **Finish**.
+
+## Context
+
+### Area architecture
+
+Each of the three skills ends in a Complete phase that runs a finishing loop:
+
+- `/yoke:task` Phase 6 (`skills/task/SKILL.md:254-273`) under a `**Loop:**` heading.
+- `/yoke:plan` Phase 8 (`skills/plan/SKILL.md:280-299`) under a `**Loop:**` heading.
+- `/yoke:do` Phase 7 (`skills/do/SKILL.md:279-291`) with no `**Loop:**` heading — a flat 3-option list followed by a `Handling the choice:` block.
+
+Each loop offers 3 options via `AskUserQuestion`:
+
+1. Run the next skill (recommended).
+2. **Review via revdiff**.
+3. Finish.
+
+Today the **Review via revdiff** branch packs every post-close step into one dense prose bullet, with the `/revdiff` Skill tool call appearing syntactically before the continuation instruction ("Loop back to the start" / "Re-present the 3 options"). The model reads the Skill tool call as the bullet's terminal action and exits, so:
+
+- It skips the check for revdiff annotations.
+- It skips applying annotations to the artifact file (`/task`, `/plan`) and skips implementing the code changes they describe (`/do`).
+- It skips re-presenting `AskUserQuestion`.
+
+The root cause is syntactic position, not missing content. The previous PR (#1) tried to clarify loop-back wording (`bef82f3` → `1e18e1b`) but left the Skill call last in the bullet, so the bug persisted.
+
+### Files to change
+
+- `skills/task/SKILL.md:272` — rewrite the "Review via revdiff" bullet (inline numbered steps).
+- `skills/plan/SKILL.md:298` — rewrite the "Review via revdiff" bullet (inline numbered steps).
+- `skills/do/SKILL.md:290` — rewrite the "Review via revdiff" bullet (inline numbered steps, with a `/do`-specific sub-list for base cascade, report append, gitignore check, and auto-commit).
+
+### Patterns to reuse
+
+- Inline numbered steps under a bullet — the minimal, self-contained fix (the architect's pick over a shared reference doc, which would reintroduce the same "last-action-is-tool-call" bug at the reference site).
+- `/fix` Phase 7 "go back to Phase 1 (SLUG is preserved)" (`skills/fix/SKILL.md:248`) — the canonical destination-naming pattern. Adopt the phrasing "Return to the 'Offer 3 options' step above" for the loop-back step.
+- Empty-vs-non-empty return detection — treat the `/revdiff` Skill return as text; a non-empty return means annotations are present and must be applied, an empty return means the user quit without annotating and the apply step is skipped.
+- Existing `/do` Phase 7 semantics from PR #1 — default-base cascade (`skills/gp/agents/git-pre-checker.md:43-54`), append under `## Review notes`, `.gitignore` check mirroring Phase 6c, auto-commit `TICKET docs(SLUG): append review notes`, install-hint fallback. Keep every semantic intact; only restructure the ordering.
+- `/do` code-change execution — the orchestrator applies code changes from annotations inline (no new agent dispatch), mirroring `/do`'s existing orchestrator-driven report-append pattern.
+
+### Tests
+
+The repository has no automated tests (markdown-only plugin, confirmed in `docs/ai/1-replace-plannotator-with-revdiff/1-replace-plannotator-with-revdiff-review.md:48`). Verification is manual per-skill run plus the existing markdown/JSON validators.
+
+## Requirements
+
+1. Rewrite the "Review via revdiff" bullet in `skills/task/SKILL.md:272` so it lists post-close steps before calling `/revdiff`. Required steps, in order: (a) announce continuation; (b) call the Skill tool with `/revdiff` and `--only docs/ai/<task-slug>/<task-slug>-task.md`; (c) if the Skill return is non-empty, apply the returned annotations to the task file and overwrite it; if empty, skip this step; (d) return to the "Offer 3 options" step above. Preserve the install-hint fallback (print `/plugin marketplace add umputun/revdiff` and `/plugin install revdiff@umputun-revdiff`), and after printing, return to the "Offer 3 options" step above.
+2. Apply the same 4-step structure to `skills/plan/SKILL.md:298`, substituting `--only docs/ai/<TASK_SLUG>/<TASK_SLUG>-plan.md` and "apply to the plan file" for the task-file wording.
+3. Rewrite the "Review via revdiff" bullet in `skills/do/SKILL.md:290` with the same 4-step structure. Step (b) calls `/revdiff` with `<base>...HEAD`, where `<base>` resolves via the existing cascade `git symbolic-ref refs/remotes/origin/HEAD` → `origin/main` → `origin/master` → `main` (`skills/gp/agents/git-pre-checker.md:43-54`). Step (c) — when the Skill return is non-empty — does two things: (c1) the orchestrator applies code changes described in the annotations inline (no agent dispatch); (c2) appends the annotation text to `docs/ai/<SLUG>/<SLUG>-report.md` under an existing `## Review notes` heading, or creates the heading and appends under it; then checks whether `docs/ai/` is in `.gitignore` (same check as Phase 6c) and, if not ignored, runs `git add docs/ai/<SLUG>/<SLUG>-report.md && git commit -m "TICKET docs(SLUG): append review notes"` per `${CLAUDE_PLUGIN_ROOT}/skills/gca/reference/commit-convention.md`. Step (d) returns to the "Offer 3 options" step above. Preserve the install-hint fallback as in requirement 1.
+4. In all three rewrites, state the continuation obligation explicitly before the Skill call so the model reads the `/revdiff` dispatch as a middle step, not the terminal action. Use the phrasing "After revdiff closes, continue with the following steps:" (or equivalent) before step (a).
+5. Use identical loop-back phrasing in all three files: "Return to the 'Offer 3 options' step above."
+6. The loop must run until the user picks **Finish** (or the next-skill option). Every non-Finish branch — including the install-hint fallback and the empty-annotations case — returns to the "Offer 3 options" step above.
+
+## Constraints
+
+- Edit only the "Review via revdiff" bullet in each of the three SKILL.md files. Do not restructure surrounding Phase Complete text, the 3-option `AskUserQuestion` list itself, or the other two branches (Run next skill, Finish).
+- Do not create a shared reference doc (`lib/revdiff-protocol.md` or `skills/*/reference/revdiff-protocol.md`). Per architect analysis, indirection would reintroduce the "last-action-is-tool-call" bug at the reference site. Per user confirmation, the fix stays inline per skill.
+- Do not edit `docs/task.md:25`, `docs/plan.md:17,27-28`, `docs/do.md:18,28`, or the `README.md:274-323` Interactive review section. Their current wording ("revdiff → loop", "annotation fold-back") stays accurate after this change.
+- Do not touch `/fix`, `/review`, `/explore`, `/gca`, `/gp`, `/pr`, `/gst`, `/hi`, or `/bootstrap` — they have no `/revdiff` branch and sit explicitly out of scope (confirmed in `docs/ai/1-replace-plannotator-with-revdiff/1-replace-plannotator-with-revdiff-review.md:60-63`).
+- Do not touch historical artifacts under `docs/ai/1-replace-plannotator-with-revdiff/`.
+- Do not change `/do` Phase 7's default-base cascade, the `## Review notes` heading semantics, the `.gitignore` check, the commit-message format, or the install-hint fallback. Keep every semantic from PR #1 intact — this task only restructures ordering and makes obligations explicit.
+- Do not hoist `/do`'s sub-steps (base cascade, report append, gitignore check, auto-commit) to top-level numbering. Keep them nested under step (c) so the visual hierarchy signals "these belong to one of three choices", not "these are distinct Phase steps".
+- Do not introduce new agent dispatches for `/do` annotation application — the orchestrator edits inline (per user confirmation), mirroring the existing append-to-report flow.
+- Do not add a revdiff return-format schema to the SKILL.md or README. Detection is "non-empty return = annotations present, empty return = skip apply" (per user confirmation), without pinning revdiff's internal schema.
+- Do not skip the Telegram notification paths or alter their wording. This change needs no new `notify.sh` call.
+
+## Verification
+
+- **Manual — `/yoke:task` with annotations:** run `/yoke:task <ticket>` → reach Phase 6 Complete → pick "Review via revdiff" → add annotations in revdiff → quit → task file is overwritten with annotations applied → `AskUserQuestion` with 3 options re-appears.
+- **Manual — `/yoke:task` without annotations:** same as above, but quit revdiff without adding annotations → task file unchanged → `AskUserQuestion` with 3 options re-appears.
+- **Manual — `/yoke:plan` with annotations:** run `/yoke:plan <task-path>` → reach Phase 8 Complete → pick "Review via revdiff" → annotate → quit → plan file overwritten with annotations → `AskUserQuestion` re-appears.
+- **Manual — `/yoke:plan` without annotations:** same, quit without annotating → plan file unchanged → `AskUserQuestion` re-appears.
+- **Manual — `/yoke:do` with annotations:** run `/yoke:do <plan-path>` → reach Phase 7 Complete → pick "Review via revdiff" → annotate code regions → quit → code changes described in annotations land in the affected files → annotation text appended under `## Review notes` in `docs/ai/<SLUG>/<SLUG>-report.md` → (if `docs/ai/` not in `.gitignore`) auto-commit `TICKET docs(SLUG): append review notes` created → `AskUserQuestion` re-appears.
+- **Manual — `/yoke:do` without annotations:** same as above, quit without annotating → no code changes, no report append, no commit → `AskUserQuestion` re-appears.
+- **Manual — revdiff plugin missing:** in any of the three skills, pick "Review via revdiff" when `/revdiff` is not installed → install-hint prints (`/plugin marketplace add umputun/revdiff` and `/plugin install revdiff@umputun-revdiff`) → `AskUserQuestion` re-appears.
+- **Manual — loop termination:** in any of the three skills, loop through "Review via revdiff" at least twice, then pick **Finish** → loop exits and the skill reports the file path.
+- **Manual — `docs/ai/` gitignored (`/yoke:do` only):** add `docs/ai/` to local `.gitignore` → `/yoke:do` Phase 7 revdiff path with annotations → report file updates, auto-commit is skipped, `AskUserQuestion` re-appears.
+- `python3 -c "import json; json.load(open('.claude-plugin/plugin.json')); json.load(open('.claude-plugin/marketplace.json')); print('OK')"` → `OK`.
+- `head -1 skills/task/SKILL.md skills/plan/SKILL.md skills/do/SKILL.md` → each starts with `---` (YAML frontmatter preserved).
+- `pnpm run format:check` → no new failures.
+
+### Edge cases
+
+- revdiff returns no annotations (user quit without commenting) — skip the apply/execute step, but still re-present `AskUserQuestion`.
+- revdiff plugin not installed — print the install-hint and re-present `AskUserQuestion`.
+- `/do` annotations describe both code changes and prose notes — handle both: apply code edits inline, append the full annotation text to the report under `## Review notes`.
+- Repeat `/do` revdiff invocations — annotations append under the existing `## Review notes` heading, with no duplicate heading (behavior preserved from PR #1's `1e18e1b` fix).
+- User picks "Review via revdiff" three times in a row — re-present the loop each time, no silent exits.
+
+## Materials
+
+- [GitHub Issue #11](https://github.com/yokeloop/yoke/issues/11)
+- `skills/task/SKILL.md` — task skill (Phase 6 Complete loop, line 272)
+- `skills/plan/SKILL.md` — plan skill (Phase 8 Complete loop, line 298)
+- `skills/do/SKILL.md` — do skill (Phase 7 Complete, line 290)
+- `skills/fix/SKILL.md` — fix skill (Phase 7 — reference for the destination-naming loop pattern, lines 246-250)
+- `skills/gp/agents/git-pre-checker.md` — default-base cascade used by `/do` Phase 7 (lines 43-54)
+- `${CLAUDE_PLUGIN_ROOT}/skills/gca/reference/commit-convention.md` — commit-message convention
+- `docs/ai/1-replace-plannotator-with-revdiff/1-replace-plannotator-with-revdiff-review.md` — prior PR review report (scope exclusions at lines 60-63, prior loop-back fix attempt at line 99)
+- `README.md:274-323` — Interactive review (revdiff) section (read-only reference)

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -293,9 +293,9 @@ Report the path to the report file and offer 3 options via AskUserQuestion:
      - If the annotations describe code changes, apply those code changes inline (orchestrator edits — do not dispatch a sub-agent). If the annotations are prose-only, skip the code-edit step.
      - Append the full annotation text to `docs/ai/<SLUG>/<SLUG>-report.md`: if a `## Review notes` heading already exists in the file, append under the existing heading; otherwise create the heading and append under it.
      - Check `.gitignore` for `docs/ai/` (same as Phase 6c). If ignored, skip the auto-commit. Otherwise, run `git add docs/ai/<SLUG>/<SLUG>-report.md && git commit -m "TICKET docs(SLUG): append review notes"` (per `${CLAUDE_PLUGIN_ROOT}/skills/gca/reference/commit-convention.md`).
-     If the Skill return is empty, skip this entire step.
+       If the Skill return is empty, skip this entire step.
   3. Return to the "Offer 3 options" step above.
-  If the plugin is missing — print `Install the revdiff plugin:` followed by `  /plugin marketplace add umputun/revdiff` and `  /plugin install revdiff@umputun-revdiff`, then return to the "Offer 3 options" step above.
+     If the plugin is missing — print `Install the revdiff plugin:` followed by `  /plugin marketplace add umputun/revdiff` and `  /plugin install revdiff@umputun-revdiff`, then return to the "Offer 3 options" step above.
 - **Finish:** report the path to the report file
 
 ---

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -289,11 +289,10 @@ Report the path to the report file and offer 3 options via AskUserQuestion:
 - **Run /yoke:review:** invoke the Skill tool with `/yoke:review` and argument `<SLUG>`
 - **Review via revdiff:** After revdiff closes, continue with the following steps:
   1. Resolve the default base via the cascade `git symbolic-ref refs/remotes/origin/HEAD` → `origin/main` → `origin/master` → fallback `main` (see `skills/gp/agents/git-pre-checker.md:43-54`). Call the Skill tool with `/revdiff` and the argument `<default-base>...HEAD`.
-  2. If the Skill return is non-empty:
+  2. If the Skill return is empty, skip this entire step. Otherwise:
      - If the annotations describe code changes, apply those code changes inline (orchestrator edits — do not dispatch a sub-agent). If the annotations are prose-only, skip the code-edit step.
      - Append the full annotation text to `docs/ai/<SLUG>/<SLUG>-report.md`: if a `## Review notes` heading already exists in the file, append under the existing heading; otherwise create the heading and append under it.
      - Check `.gitignore` for `docs/ai/` (same as Phase 6c). If ignored, skip the auto-commit. Otherwise, run `git add docs/ai/<SLUG>/<SLUG>-report.md && git commit -m "TICKET docs(SLUG): append review notes"` (per `${CLAUDE_PLUGIN_ROOT}/skills/gca/reference/commit-convention.md`).
-       If the Skill return is empty, skip this entire step.
   3. Return to the "Offer 3 options" step above.
      If the plugin is missing — print `Install the revdiff plugin:` followed by `  /plugin marketplace add umputun/revdiff` and `  /plugin install revdiff@umputun-revdiff`, then return to the "Offer 3 options" step above.
 - **Finish:** report the path to the report file

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -287,7 +287,15 @@ Report the path to the report file and offer 3 options via AskUserQuestion:
 **Handling the choice:**
 
 - **Run /yoke:review:** invoke the Skill tool with `/yoke:review` and argument `<SLUG>`
-- **Review via revdiff:** resolve the default base via the cascade `git symbolic-ref refs/remotes/origin/HEAD` → `origin/main` → `origin/master` → fallback `main` (see `skills/gp/agents/git-pre-checker.md:43-54`). Call the Skill tool with `/revdiff` and the argument `<default-base>...HEAD`. Append returned annotations to `docs/ai/<SLUG>/<SLUG>-report.md`: if a `## Review notes` heading already exists in the file, append under the existing heading; otherwise create the heading. Check `.gitignore` for `docs/ai/` (same as Phase 6c) — if ignored, skip the auto-commit; otherwise auto-commit with `git add docs/ai/<SLUG>/<SLUG>-report.md && git commit -m "TICKET docs(SLUG): append review notes"` (per `${CLAUDE_PLUGIN_ROOT}/skills/gca/reference/commit-convention.md`). Re-present the 3 options via AskUserQuestion (skip the report-path re-print). If the plugin is missing — print `Install the revdiff plugin:` followed by `  /plugin marketplace add umputun/revdiff` and `  /plugin install revdiff@umputun-revdiff`, then re-present the 3 options.
+- **Review via revdiff:** After revdiff closes, continue with the following steps:
+  1. Resolve the default base via the cascade `git symbolic-ref refs/remotes/origin/HEAD` → `origin/main` → `origin/master` → fallback `main` (see `skills/gp/agents/git-pre-checker.md:43-54`). Call the Skill tool with `/revdiff` and the argument `<default-base>...HEAD`.
+  2. If the Skill return is non-empty:
+     - If the annotations describe code changes, apply those code changes inline (orchestrator edits — do not dispatch a sub-agent). If the annotations are prose-only, skip the code-edit step.
+     - Append the full annotation text to `docs/ai/<SLUG>/<SLUG>-report.md`: if a `## Review notes` heading already exists in the file, append under the existing heading; otherwise create the heading and append under it.
+     - Check `.gitignore` for `docs/ai/` (same as Phase 6c). If ignored, skip the auto-commit. Otherwise, run `git add docs/ai/<SLUG>/<SLUG>-report.md && git commit -m "TICKET docs(SLUG): append review notes"` (per `${CLAUDE_PLUGIN_ROOT}/skills/gca/reference/commit-convention.md`).
+     If the Skill return is empty, skip this entire step.
+  3. Return to the "Offer 3 options" step above.
+  If the plugin is missing — print `Install the revdiff plugin:` followed by `  /plugin marketplace add umputun/revdiff` and `  /plugin install revdiff@umputun-revdiff`, then return to the "Offer 3 options" step above.
 - **Finish:** report the path to the report file
 
 ---

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -299,7 +299,7 @@ Offer 3 options through AskUserQuestion:
   1. Call the Skill tool with `/revdiff` and the argument `--only docs/ai/<TASK_SLUG>/<TASK_SLUG>-plan.md`.
   2. If the Skill return is non-empty, apply the returned annotations to the plan file and overwrite `docs/ai/<TASK_SLUG>/<TASK_SLUG>-plan.md`. If the return is empty, skip this step.
   3. Return to the "Offer 3 options" step above.
-  If the plugin is missing — print `Install the revdiff plugin:` followed by `  /plugin marketplace add umputun/revdiff` and `  /plugin install revdiff@umputun-revdiff`, then return to the "Offer 3 options" step above.
+     If the plugin is missing — print `Install the revdiff plugin:` followed by `  /plugin marketplace add umputun/revdiff` and `  /plugin install revdiff@umputun-revdiff`, then return to the "Offer 3 options" step above.
 - **Finish:** report the file path. Exit the loop.
 
 ---

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -295,7 +295,11 @@ Offer 3 options through AskUserQuestion:
 **Handle the choice:**
 
 - **Run /yoke:do:** call the Skill tool with `/yoke:do` and the argument `docs/ai/<TASK_SLUG>/<TASK_SLUG>-plan.md`. Exit the loop.
-- **Review via revdiff:** call the Skill tool with `/revdiff` and the argument `--only docs/ai/<TASK_SLUG>/<TASK_SLUG>-plan.md`. Apply the returned annotations, overwrite the plan file. Loop back to the start. If the plugin is missing — print `Install the revdiff plugin:` followed by `  /plugin marketplace add umputun/revdiff` and `  /plugin install revdiff@umputun-revdiff`, then loop back to the start.
+- **Review via revdiff:** After revdiff closes, continue with the following steps:
+  1. Call the Skill tool with `/revdiff` and the argument `--only docs/ai/<TASK_SLUG>/<TASK_SLUG>-plan.md`.
+  2. If the Skill return is non-empty, apply the returned annotations to the plan file and overwrite `docs/ai/<TASK_SLUG>/<TASK_SLUG>-plan.md`. If the return is empty, skip this step.
+  3. Return to the "Offer 3 options" step above.
+  If the plugin is missing — print `Install the revdiff plugin:` followed by `  /plugin marketplace add umputun/revdiff` and `  /plugin install revdiff@umputun-revdiff`, then return to the "Offer 3 options" step above.
 - **Finish:** report the file path. Exit the loop.
 
 ---

--- a/skills/task/SKILL.md
+++ b/skills/task/SKILL.md
@@ -269,7 +269,11 @@ Offer 3 options through AskUserQuestion:
 **Handle the choice:**
 
 - **Run /yoke:plan:** call the Skill tool with `/yoke:plan` and the argument `docs/ai/<task-slug>/<task-slug>-task.md`. Exit.
-- **Review via revdiff:** call the Skill tool with `/revdiff` and the argument `--only docs/ai/<task-slug>/<task-slug>-task.md`. Apply the returned annotations, overwrite the file. Loop back to the start. If the plugin is missing — print `Install the revdiff plugin:` followed by `  /plugin marketplace add umputun/revdiff` and `  /plugin install revdiff@umputun-revdiff`, then loop back to the start.
+- **Review via revdiff:** After revdiff closes, continue with the following steps:
+  1. Call the Skill tool with `/revdiff` and the argument `--only docs/ai/<task-slug>/<task-slug>-task.md`.
+  2. If the Skill return is non-empty, apply the returned annotations to the task file and overwrite `docs/ai/<task-slug>/<task-slug>-task.md`. If the return is empty, skip this step.
+  3. Return to the "Offer 3 options" step above.
+  If the plugin is missing — print `Install the revdiff plugin:` followed by `  /plugin marketplace add umputun/revdiff` and `  /plugin install revdiff@umputun-revdiff`, then return to the "Offer 3 options" step above.
 - **Finish:** report the file path. Exit.
 
 ---

--- a/skills/task/SKILL.md
+++ b/skills/task/SKILL.md
@@ -273,7 +273,7 @@ Offer 3 options through AskUserQuestion:
   1. Call the Skill tool with `/revdiff` and the argument `--only docs/ai/<task-slug>/<task-slug>-task.md`.
   2. If the Skill return is non-empty, apply the returned annotations to the task file and overwrite `docs/ai/<task-slug>/<task-slug>-task.md`. If the return is empty, skip this step.
   3. Return to the "Offer 3 options" step above.
-  If the plugin is missing — print `Install the revdiff plugin:` followed by `  /plugin marketplace add umputun/revdiff` and `  /plugin install revdiff@umputun-revdiff`, then return to the "Offer 3 options" step above.
+     If the plugin is missing — print `Install the revdiff plugin:` followed by `  /plugin marketplace add umputun/revdiff` and `  /plugin install revdiff@umputun-revdiff`, then return to the "Offer 3 options" step above.
 - **Finish:** report the file path. Exit.
 
 ---


### PR DESCRIPTION
<!-- yoke:start -->

## Summary

Closes #11

Fixes a silent-exit bug in the "Review via revdiff" branch of the Complete-phase loop in `/task`, `/plan`, and `/do`. The prior bullet placed the `/revdiff` Skill call as the syntactically last action, causing the model to treat it as terminal and skip the post-close obligations (check annotations → apply/execute → re-present `AskUserQuestion`). This PR restructures each bullet so the continuation obligation appears before the Skill call, with numbered steps guiding the model through call → apply → loop-back, and adds an explicit empty-return skip branch.

## Attention

1. **`skills/task/SKILL.md:272`** — Phase 6 "Review via revdiff" bullet rewritten as 4-step inline sequence.
2. **`skills/plan/SKILL.md:298`** — Phase 8 "Review via revdiff" bullet rewritten with the same template.
3. **`skills/do/SKILL.md:290`** — Phase 7 "Review via revdiff" bullet rewritten; step 2 carries a nested sub-list preserving every PR #1 semantic (base cascade, `## Review notes` append, `.gitignore` check, auto-commit, install-hint fallback).
4. **`skills/do/SKILL.md:292`** — step 2 leads with the empty-return skip clause for unambiguous scope (review fix).

## Design decisions

1. **Inline numbered steps, no shared reference doc** — a shared `lib/revdiff-protocol.md` would have reintroduced the root-cause bug at the reference site.
2. **Continuation obligation stated BEFORE the Skill call** — the literal phrase `After revdiff closes, continue with the following steps:` opens each bullet. This is the core root-cause fix; the prior PR #1 (`1e18e1b`) clarified wording but kept the Skill call last, so the bug persisted.
3. **Byte-identical loop-back phrase across all three files** (`Return to the "Offer 3 options" step above.`) — matches `/fix` Phase 7's destination-naming pattern; enables grep-based consistency checks.
4. **Empty-return skip leads /do step 2** — restructured to open with "If the Skill return is empty, skip this entire step. Otherwise:" so the skip scope is unambiguous at the markdown AST level (not just via prose self-identification), and prettier-safe.

## Questions

1. The verification-spec defect (case-sensitive grep vs capitalized "Return" at sentence-start, lowercase "return" mid-sentence) was handled by switching the validation grep to case-insensitive. Worth updating the plan template to recommend case-insensitive grep for prose-embedded phrases?
2. `/task` and `/plan` install-hint fallbacks sit at 5-space indent (continuation of step 3 in the markdown AST). Text self-identification is sufficient, but is there value in a /do-style restructure for consistency?
3. No version pin on the external revdiff plugin — still open from PR #1 review question 2.

## Risks

- No code paths broken — markdown-only edits to skill instructions.
- External dependency surface area unchanged — revdiff plugin install-hint fallback preserved verbatim from PR #1.
- PR #1 `/do` Phase 7 semantics (cascade reference, `## Review notes` heading, gitignore check, auto-commit) preserved and verified by Task 4 greps.

## Test plan

- [ ] `/yoke:task <ticket>` → Phase 6 pick "Review via revdiff" → annotate → quit → task file overwritten → `AskUserQuestion` re-appears.
- [ ] `/yoke:task` → Phase 6 pick "Review via revdiff" → quit without annotating → task file unchanged → `AskUserQuestion` re-appears.
- [ ] `/yoke:plan <task-path>` → Phase 8 same two outcomes for the plan file.
- [ ] `/yoke:do <plan-path>` → Phase 7 pick "Review via revdiff" → annotate code regions → quit → code changes implemented inline → annotations appended under `## Review notes` → auto-commit `#11 docs(...): append review notes` → `AskUserQuestion` re-appears.
- [ ] `/yoke:do` → Phase 7 pick "Review via revdiff" → quit without annotating → no code change, no report append, no commit → `AskUserQuestion` re-appears.
- [ ] Negative — uninstall revdiff → pick "Review via revdiff" → install hint prints → `AskUserQuestion` re-appears without crash.
- [ ] Loop termination — loop "Review via revdiff" twice, then pick **Finish** → loop exits.
- [ ] Gitignore negative — add `docs/ai/` to `.gitignore` → `/yoke:do` Phase 7 revdiff with annotations → report updated, auto-commit skipped, `AskUserQuestion` re-appears.

## Changes

| File                                                        | Action   | Description                                                                                           |
| ----------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
| `skills/task/SKILL.md`                                      | modified | Phase 6 "Review via revdiff" bullet restructured to 4-step inline form                                |
| `skills/plan/SKILL.md`                                      | modified | Phase 8 "Review via revdiff" bullet restructured to 4-step inline form                                |
| `skills/do/SKILL.md`                                        | modified | Phase 7 "Review via revdiff" bullet restructured; step 2 leads with empty-return skip                 |
| `docs/ai/11-revdiff-flow-after-close/*-task.md`             | added    | Task definition artifact                                                                              |
| `docs/ai/11-revdiff-flow-after-close/*-plan.md`             | added    | Implementation plan artifact                                                                          |
| `docs/ai/11-revdiff-flow-after-close/*-report.md`           | added    | Execution report artifact                                                                             |
| `docs/ai/11-revdiff-flow-after-close/*-review.md`           | added    | Review report artifact                                                                                |

## Commits

- `d34616f` `#11 docs(11-revdiff-flow-after-close): add task definition`
- `215f54c` `#11 docs(11-revdiff-flow-after-close): add implementation plan`
- `9d52739` `#11 fix(11-revdiff-flow-after-close): restructure task revdiff bullet to execute annotations after close`
- `d4eaa4e` `#11 fix(11-revdiff-flow-after-close): restructure plan revdiff bullet to execute annotations after close`
- `ce99939` `#11 fix(11-revdiff-flow-after-close): restructure do revdiff bullet to execute annotations after close`
- `19a9d21` `#11 style(11-revdiff-flow-after-close): apply prettier to revdiff bullets`
- `186e49d` `#11 docs(11-revdiff-flow-after-close): add execution report`
- `e34ff9d` `#11 fix(11-revdiff-flow-after-close): lead do step 2 with empty-return skip for unambiguous scope`
- `df1d4a0` `#11 docs(11-revdiff-flow-after-close): add review report`

## Validation

- `python3 plugin.json/marketplace.json parse` → OK
- `head -1 skills/{task,plan,do}/SKILL.md` → each file starts with `---`
- `grep "After revdiff closes, continue..."` → 1 match per file
- `grep -i "Return to the \"Offer 3 options\"..."` → 2 matches per file
- `grep "If the ... return is empty"` → 1 match per file
- `grep "append review notes"` / `## Review notes` / cascade ref (`do` only) → all 1 match
- `pnpm run format:check` → all matched files use Prettier code style

---

<!-- yoke:end -->
