### PR TITLE
feat(bootstrap): sibling-aware bootstrap — hypothesis detect, flow pre-fill, fact-owner links

### DIFF
--- a/.yoke/adr/0010-cross-repo-bootstrap-via-additional-directories.md
+++ b/.yoke/adr/0010-cross-repo-bootstrap-via-additional-directories.md
@@ -1,0 +1,37 @@
+# Cross-repo bootstrap: siblings via additionalDirectories, links instead of copies
+
+Running bootstrap across six same-org React projects (velvetnet ×4, TB-FF ×2,
+2026-07-09) showed the real cost of repo-blind onboarding is drift, not tokens:
+the same org facts were re-derived independently in every repo and diverged —
+the ui-kit publish command recorded three different ways across four flow.md
+files, ticket target-state Review vs Staging for one YouTrack pipeline,
+mutually exclusive consumers lists, and one session concluded the tracker
+project didn't exist while three parallel siblings found it. A re-bootstrap
+cost as much as a first run (~528k subagent tokens for a +37/−42 diff).
+
+We decided (2026-07-09), three facets of one design:
+
+1. **Discovery.** Siblings are found only through `additionalDirectories` in
+   the project's `.claude/settings.local.json` — when it names an org directory
+   or specific checkouts, that IS the user's declaration that the repos belong
+   together. No new org-level artifact; without the setting bootstrap behaves
+   exactly as before, so nothing changes for other users of the plugin.
+2. **Reuse.** An existing `yoke-context.md` — a stack-matching sibling's on
+   first bootstrap, the repo's own on re-run — is fed to the detect agents as a
+   hypothesis to verify against the code, reporting differences only. Flow
+   questions arrive pre-filled with the sibling's answers and collapse into one
+   confirmation. Unconfirmed hypotheses never enter the artifacts, so a
+   sibling's drift (the wrong-tracker conclusion) is not inherited.
+3. **Representation.** Cross-repo knowledge is an index, not a canon: the Repos
+   section of `.yoke/flow.md` holds, per linked repo, a role, checkout path,
+   one-line description, and a pointer to its `.yoke/`. Shared facts live only
+   in their fact owner (a library's publish procedure and consumers in the
+   library's own flow.md); consumers link, and `/merge` follows the link.
+
+Rejected: an org-level profile file above the repos (a new entity outside any
+git repo that other developers would never maintain); silent inheritance
+(fast, but propagates sibling drift); an explicit `bootstrap like ../repo`
+argument as the primary path (kept possible, but the user shouldn't have to
+remember it); canonicalizing shared facts across sibling flow.md files (a
+strict shared rulebook nobody will keep updated — links age better than
+copies).

--- a/.yoke/context.md
+++ b/.yoke/context.md
@@ -74,6 +74,30 @@ implementation details (those live in `.yoke/adr/` and the PRDs under
   deploy/release, ticket transition, worktree cleanup, return to the default
   branch. Never runs on its own — merging stays the user's decision.
 
+## Cross-repo awareness (decided 2026-07-09)
+
+- **Sibling** — a neighboring repo checkout reachable through
+  `additionalDirectories` in the project's `.claude/settings.local.json` and
+  carrying its own `.yoke/` artifacts. The only discovery signal for cross-repo
+  reuse: when the setting names an org directory or specific checkouts, that IS
+  the declaration that the repos belong together. No dedicated org-level
+  artifact exists; without the setting, bootstrap behaves as before.
+- **Hypothesis profile** — an existing `yoke-context.md` handed to the detect
+  agents as a starting claim to verify against the code, reporting only
+  differences instead of deriving everything from scratch. Two sources, one
+  mechanism: a stack-matching sibling's profile (first bootstrap) or the repo's
+  own previous profile (re-bootstrap). Never inherited silently — a hypothesis
+  a detect agent did not confirm does not enter the artifacts.
+- **Repos index** — the Repos section of `.yoke/flow.md` read as a pointer map:
+  for each linked repo a role, checkout path, one-line description, and a
+  pointer to its `.yoke/`. Links, not copies — enough to orient in a sibling,
+  never a mirror of its content.
+- **Fact owner** — the single repo where a shared fact lives; every other repo
+  links to the owner instead of restating the fact. A library's publish
+  procedure and consumers list live in the library's own `flow.md`; `/merge`
+  in a consumer follows the link. Ends the drift where the same publish
+  command was recorded three different ways across one org.
+
 ## do modes
 
 `do` is the universal execution tool; it auto-detects its mode from the input:

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -20,15 +20,16 @@ Fires on prompts like: "bootstrap", "configure yoke", "prepare the project", "in
 
 ## Phases
 
-1. **Stack detection** — identify languages, frameworks, build tools
-2. **Architecture analysis** — map directories, layers, dependencies
-3. **Convention scanning** — code style, naming, patterns
-4. **Existing rules detection** — linters, CI, configs
-5. **Validation** — check collected data
-6. **CLAUDE.md generation** — build the instructions, wired to the `.yoke/` conventions
-7. **Context + `.yoke/` scaffold** — write `.yoke/yoke-context.md` and scaffold `.yoke/` (`context.md`, `journal.md`, `ai/`, `adr/`)
-8. **Automation recommendations** — suggestions for hooks and scripts
-9. **Verification** — final check of CLAUDE.md, context, and the `.yoke/` skeleton
+1. **Sibling discovery** — find already-bootstrapped neighbors via `additionalDirectories`, pick a hypothesis profile (ADR-0010)
+2. **Stack detection** — identify languages, frameworks, build tools
+3. **Architecture analysis** — map directories, layers, dependencies
+4. **Convention scanning** — code style, naming, patterns
+5. **Existing rules detection** — linters, CI, configs
+6. **Validation** — check collected data
+7. **CLAUDE.md generation** — build the instructions, wired to the `.yoke/` conventions
+8. **Context + `.yoke/` scaffold** — write `.yoke/yoke-context.md` and scaffold `.yoke/` (`context.md`, `journal.md`, `ai/`, `adr/`)
+9. **Automation recommendations** — suggestions for hooks and scripts
+10. **Verification** — final check of CLAUDE.md, context, and the `.yoke/` skeleton
 
 (Simplified overview; the actual pipeline is 7 phases including Preflight, Confirm, and Commit.)
 
@@ -37,6 +38,10 @@ Fires on prompts like: "bootstrap", "configure yoke", "prepare the project", "in
 - Orchestrator with 10 sub-agents
 - Interactive: asks clarifying questions via AskUserQuestion
 - Entry point for a new project in yoke
+- Sibling-aware: a stack-matching neighbor's `yoke-context.md` (or the repo's own
+  on a re-run) is verified as a hypothesis instead of re-deriving everything;
+  the neighbor's flow map pre-fills the flow interview. Shared facts are linked
+  to their owner repo, never copied (ADR-0010)
 
 ## Connections
 

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -32,8 +32,15 @@ CLAUDE.md + `.yoke/yoke-context.md` + `.yoke/` skeleton → verify → build
 every agent dispatch, the PROJECT_PROFILE shape, the flow.md questions, and the
 commit steps.
 
-Two 3.0 duties the pipeline now carries:
+Three duties the pipeline now carries:
 
+- **Sibling awareness (ADR-0010).** When `.claude/settings.local.json` declares
+  `additionalDirectories`, discover sibling checkouts with `.yoke/` there and
+  reuse them: a stack-matching sibling's `yoke-context.md` (or the repo's own on
+  a re-run) becomes a **hypothesis** the detect agents verify against the code,
+  and the sibling's flow map pre-fills the flow interview down to one
+  confirmation. Nothing is inherited unverified; shared facts stay with their
+  owner repo and are linked, not copied. No siblings → identical to before.
 - **Flow map.** Ask about linked repos, each repo's finish policy, and the
   tracker — one AskUserQuestion each, recommended answer first, skipping whatever
   the repo already answers — then write `.yoke/flow.md` per the format contract

--- a/skills/bootstrap/agents/architecture-mapper.md
+++ b/skills/bootstrap/agents/architecture-mapper.md
@@ -12,6 +12,16 @@ color: yellow
 
 Map the project's architecture.
 
+## Hypothesis (optional input)
+
+The orchestrator may append a HYPOTHESIS block — the Architecture findings of a
+similar sibling repo, or of this repo's previous run (ADR-0010). When present,
+verify instead of deriving: check each claim against this codebase, spend the
+effort on differences, and mark every output field `CONFIRMED` (matches the
+hypothesis) or `CHANGED` (differs — return the verified value). Never copy an
+unverified claim into the output. No HYPOTHESIS block → run the full process
+below.
+
 ## Process
 
 All commands are read-only. Run them in order.

--- a/skills/bootstrap/agents/bootstrap-verifier.md
+++ b/skills/bootstrap/agents/bootstrap-verifier.md
@@ -38,7 +38,7 @@ Confirm the flow map exists and carries a Repos section:
 test -f .yoke/flow.md && grep -qi '^##[[:space:]]*Repos' .yoke/flow.md && echo REPOS_OK || echo FLOW_ISSUE
 ```
 
-Report `YOKE_FLOW_OK: true|false`. When `.yoke/flow.md` is absent, or present without a `## Repos` section, set `YOKE_FLOW_OK: false` and state which case in ISSUES — a bootstrapped project should carry a flow map, so its absence is a reported gap, not a hard `FILES_OK: false`.
+Report `YOKE_FLOW_OK: true|false`. When `.yoke/flow.md` is absent, or present without a `## Repos` section, set `YOKE_FLOW_OK: false` with the note "(expected — written in the flow-map phase)" — the pipeline writes flow.md **after** this verification, so its absence is normal, never an ISSUES entry, and never a penalty. For the same reason a reference to `.yoke/flow.md` from CLAUDE.md is a valid forward reference, not a dangling link.
 
 ### Step 2. Sections check
 
@@ -75,10 +75,15 @@ If a conditional section is present but the list format is incorrect — mark it
 
 Extract commands from Commands and verify each one with one of:
 
-- Run `<cmd> --help 2>&1 | head -5` and confirm it's not "command not found"
 - Check presence in `package.json` scripts (for npm/pnpm/yarn commands)
 - Check presence in `Makefile` targets (for make commands)
 - Check presence in `pyproject.toml` scripts (for Python)
+- Run `<cmd> --help 2>&1 | head -5` and confirm it's not "command not found"
+
+**Presence checks only.** Never execute the project's build, lint, test, or dev
+commands themselves — validation-scanner already ran them earlier in the
+pipeline; re-running a full build here burns minutes without changing the
+verdict.
 
 ### Step 4. Paths check
 
@@ -118,3 +123,6 @@ ISSUES: <list of problems, if any>
 - Check each criterion objectively, with concrete examples.
 - When checking commands use `2>&1` to capture errors.
 - If a file does not exist — assign 0 for all criteria and QUALITY_GRADE: F.
+- **ISSUES is independent of the grade.** List every real factual problem even
+  when the score lands at A — the orchestrator gates on ISSUES, not the grade,
+  and an empty ISSUES at Grade A is what lets it proceed.

--- a/skills/bootstrap/agents/convention-scanner.md
+++ b/skills/bootstrap/agents/convention-scanner.md
@@ -12,6 +12,16 @@ color: yellow
 
 Extract code conventions from the project.
 
+## Hypothesis (optional input)
+
+The orchestrator may append a HYPOTHESIS block — the Conventions findings of a
+similar sibling repo, or of this repo's previous run (ADR-0010). When present,
+verify instead of deriving: check each claim against this codebase, spend the
+effort on differences, and mark every output field `CONFIRMED` (matches the
+hypothesis) or `CHANGED` (differs — return the verified value). Never copy an
+unverified claim into the output. No HYPOTHESIS block → run the full process
+below.
+
 ## Process
 
 All commands are read-only. Run them in order.

--- a/skills/bootstrap/agents/domain-analyzer.md
+++ b/skills/bootstrap/agents/domain-analyzer.md
@@ -12,6 +12,15 @@ color: magenta
 
 Analyze the project's domain.
 
+## Hypothesis (optional input)
+
+The orchestrator may append a HYPOTHESIS block — the Environment Variables of a
+similar sibling repo, or of this repo's previous run (ADR-0010). Domain models,
+endpoints, and abstractions rarely transfer between repos, so the hypothesis
+covers ENV_VARS only. When present, verify those against this codebase — mark
+each `CONFIRMED` or `CHANGED` — and run the full process below for everything
+else. Never copy an unverified claim into the output.
+
 ## Process
 
 All commands are read-only. Run them in order.

--- a/skills/bootstrap/agents/stack-detector.md
+++ b/skills/bootstrap/agents/stack-detector.md
@@ -12,6 +12,16 @@ color: cyan
 
 Detect the project's technology stack.
 
+## Hypothesis (optional input)
+
+The orchestrator may append a HYPOTHESIS block — the Stack findings of a
+similar sibling repo, or of this repo's previous run (ADR-0010). When present,
+verify instead of deriving: check each claim against this codebase, spend the
+effort on differences, and mark every output field `CONFIRMED` (matches the
+hypothesis) or `CHANGED` (differs — return the verified value). Never copy an
+unverified claim into the output. No HYPOTHESIS block → run the full process
+below.
+
 ## Process
 
 All commands are read-only. Run them in order.

--- a/skills/bootstrap/agents/validation-scanner.md
+++ b/skills/bootstrap/agents/validation-scanner.md
@@ -12,6 +12,16 @@ color: cyan
 
 Collect the project's validation commands.
 
+## Hypothesis (optional input)
+
+The orchestrator may append a HYPOTHESIS block — the Commands findings of a
+similar sibling repo, or of this repo's previous run (ADR-0010). When present,
+verify instead of deriving: check each claim against this codebase, spend the
+effort on differences, and mark every output field `CONFIRMED` (matches the
+hypothesis) or `CHANGED` (differs — return the verified value). Never copy an
+unverified claim into the output. No HYPOTHESIS block → run the full process
+below.
+
 ## Process
 
 All commands are read-only. Run them in order.

--- a/skills/bootstrap/agents/yoke-context-generator.md
+++ b/skills/bootstrap/agents/yoke-context-generator.md
@@ -101,7 +101,20 @@ Only create this file when it does not already exist. Check with Bash:
 test -f .yoke/context.md && echo EXISTS || echo ABSENT
 ```
 
-If ABSENT, compose and write it. Seed term stubs from DOMAIN_FINDINGS (DOMAIN_MODELS and KEY_ABSTRACTIONS). Each detected term becomes a stub entry with a placeholder definition.
+If ABSENT, compose and write it. Seed only terms that carry **project-specific
+meaning**: a term qualifies when DOMAIN_FINDINGS gives it a definition beyond
+its generic technology sense. Write each entry with that real definition — the
+glossary is domain vocabulary, not a to-do list and not an encyclopedia.
+
+Never seed:
+
+- placeholder stubs (`_fill in definition_`) — an unfilled scaffold is noise
+  the user has to clean up;
+- generic technology entries ("Supabase — a BaaS", "IPC — Electron bridge",
+  "Dexie — IndexedDB wrapper") — zero project information.
+
+Fewer real entries beat coverage. Nothing qualifies → write the title, the
+one-line note, and an empty `## Terms` heading only.
 
 File format:
 
@@ -113,10 +126,8 @@ Implementation details, architectural decisions, and PRDs live in `.yoke/adr/` a
 
 ## Terms
 
-- **<Term>** — _fill in definition_
+- **<Term>** — <project-specific definition from DOMAIN_FINDINGS (source: <path>)>
 ```
-
-If DOMAIN_FINDINGS contains no recognisable domain models or key abstractions, write the title, the one-line note, and an empty `## Terms` heading only.
 
 If the file already EXISTS, skip this step entirely — do not overwrite user edits.
 

--- a/skills/bootstrap/reference/bootstrap-pipeline.md
+++ b/skills/bootstrap/reference/bootstrap-pipeline.md
@@ -33,14 +33,14 @@ data, not template variables. Run commands with long output through
 8 phases.
 
 ```text
-0. Preflight  → verify git-repo, not a yoke-repo
-1. Detect     → 6 parallel agents investigate the project
+0. Preflight  → verify git-repo, not a yoke-repo; discover siblings & hypothesis
+1. Detect     → 6 parallel agents investigate the project (hypothesis-aware)
 2. Synthesize → aggregate PROJECT_PROFILE
 3. Generate   → CLAUDE.md + .yoke/yoke-context.md + .yoke/ skeleton + recommendations
-4. Verify     → check files and quality
-5. Flow map   → ask repos/finish/tracker + committed-vs-local-only, write .yoke/flow.md
+4. Verify     → check files and quality; gate on ISSUES
+5. Flow map   → pre-fill from a sibling or ask repos/finish/tracker + committed-vs-local-only, write .yoke/flow.md
 6. Confirm    → show the result, AskUserQuestion
-7. Commit     → commit the artifacts (respecting local-only)
+7. Commit     → branch check, commit the artifacts (respecting local-only), optional push
 ```
 
 ---
@@ -64,6 +64,26 @@ test -f .claude-plugin/plugin.json && echo "YOKE_REPO" || echo "OK"
 ```
 
 YOKE_REPO → tell the user: "/bootstrap runs in target projects, not for yoke plugins." Exit.
+
+### 0c. Siblings & hypothesis
+
+Cross-repo awareness (ADR-0010). Read-only; look only at paths the user already
+declared.
+
+1. Read `.claude/settings.local.json` → `permissions.additionalDirectories`.
+   Absent or empty → `SIBLINGS: none`, `HYPOTHESIS_PROFILE: none`; skip to Phase 1 —
+   bootstrap behaves exactly as before.
+2. Under each declared directory, list checkouts carrying `.yoke/yoke-context.md`
+   (a directory that is itself a repo counts). These are the SIBLINGS; record
+   for each: name, path, whether it has `.yoke/flow.md`.
+3. Pick HYPOTHESIS_PROFILE:
+   - This repo's own `.yoke/yoke-context.md` exists (re-run) → it is the
+     hypothesis.
+   - Else the newest `yoke-context.md` among **stack-matching** siblings — same
+     lockfile kind and same primary framework, checked with a cheap grep of
+     `package.json`/config files, not an agent.
+   - No stack match → `HYPOTHESIS_PROFILE: none`; keep SIBLINGS for Phase 5 —
+     org facts (tracker, linked repos) transfer even when the stack does not.
 
 Both conditions passed → transition to Phase 1. Mark in TodoWrite: `[x] Preflight`.
 
@@ -115,6 +135,23 @@ Dispatch 6 agents **in parallel** via the Agent tool (6 calls at once):
    ```text
    DOMAIN_MODELS, API_ENDPOINTS, KEY_ABSTRACTIONS, ENV_VARS, CODE_WORKAROUNDS
    ```
+
+**Hypothesis mode (ADR-0010).** When HYPOTHESIS_PROFILE is set, append to each
+agent's prompt the matching section of that profile plus its hypothesis
+instructions (each agent file carries a "Hypothesis" section describing the
+verify-don't-derive behavior):
+
+| Agent                   | Hypothesis section passed                                          |
+| ----------------------- | ------------------------------------------------------------------ |
+| stack-detector          | Stack                                                              |
+| architecture-mapper     | Architecture                                                       |
+| convention-scanner      | Conventions                                                        |
+| validation-scanner      | Commands                                                           |
+| domain-analyzer         | Environment Variables only — domains rarely transfer between repos |
+| existing-rules-detector | none — rules are strictly per-repo                                 |
+
+A hypothesis claim enters PROJECT_PROFILE only when the agent confirmed it
+against this codebase; an unverified claim never reaches the artifacts.
 
 Wait for all 6. If an agent returns an error or empty result — record the issue
 in VERIFY_NOTES and use empty values for that section.
@@ -231,15 +268,19 @@ ISSUES: <list of problems>
 
 ### Handling the result
 
+The gate is **ISSUES, not the grade** — a Grade A with a non-empty ISSUES list
+still carries real errors (observed: correct grade, wrong env-variable
+documentation).
+
 - **YOKE_SKELETON_OK = false** → re-dispatch yoke-context-generator to re-scaffold
   the missing `.yoke/` paths (max 1 retry), then re-verify.
-- **QUALITY_GRADE = A and YOKE_SKELETON_OK = true** → transition to Phase 5.
-- **QUALITY_GRADE < A and ISSUES is non-empty** → re-dispatch claude-md-generator
-  with ISSUES (max 1 retry):
-  1. Pass ISSUES to the claude-md-generator agent.
+- **ISSUES is empty and YOKE_SKELETON_OK = true** → transition to Phase 5.
+- **ISSUES is non-empty** (at any grade) → fix, max 1 retry:
+  1. One-line factual fixes → apply directly with Edit; anything larger →
+     re-dispatch claude-md-generator with ISSUES.
   2. Wait for completion.
   3. Re-dispatch bootstrap-verifier.
-  4. If after retry Grade < A → continue with a warning, record VERIFY_NOTES.
+  4. If ISSUES remain after the retry → continue with a warning, record VERIFY_NOTES.
 
 Mark in TodoWrite: `[x] Verify`. Transition → Phase 5.
 
@@ -252,24 +293,48 @@ of re-asking the user. Format contract: `reference/flow-md.md`. The orchestrator
 gathers the answers through AskUserQuestion (recommended answer first) and writes
 the file itself. **Skip any question the repo already answers** — infer the
 tracker from the git remote, and the single-repo case from the absence of sibling
-checkouts.
+checkouts. **Before asking, check the repo's actual state** — never offer an
+answer the repo already contradicts (e.g. local-only when `.yoke/` files are
+already tracked in git).
+
+**Pre-fill from a sibling (ADR-0010).** When Phase 0c found siblings with
+`.yoke/flow.md`, read the closest one (the hypothesis sibling first) and turn
+the interview into **one confirmation**: show the inherited answers compactly —
+linked repos and roles, tracker + target state, cascade, artifacts mode — as the
+recommended option, with "answer each question instead" as the alternative. Fall
+back to the per-question interview below only for what the user rejects or the
+sibling does not answer. When siblings contradict each other, offer the variants
+as options and recommend the one this repo's own evidence supports (CI files,
+tracker schema) — never silently inherit either side.
 
 Ask, in order:
 
 1. **Repos & finish policy.** Recommended and offered first: single repo — the
    current checkout, role `app`, finish `pr`. Alternative: add linked repos, each
    with a role (`app` | `library`) and finish policy (`pr` | `direct-push`); a
-   `direct-push` library also names its publish command and consumer repos. For an
+   `direct-push` library also names its publish command and consumer repos —
+   **in its own flow.md**: see "Repos as an index" below. For an
    obvious single-repo project, state the single-repo default and move on without
    forcing the question.
 2. **Tracker.** `github` | `youtrack` | `none`, plus the target state `merge`
    moves the ticket to on finish. Recommend and offer first `github` when the
-   remote is GitHub; otherwise `none`.
+   remote is GitHub; otherwise `none`. **Offer real states as options**: take the
+   state list from the sibling flow map or from the tracker itself (YouTrack —
+   `get_issue_fields_schema` of the project's state field; GitHub — open/closed)
+   before asking. Never offer invented generic states (Done/Fixed/Closed) when
+   the real pipeline is one schema call away.
 3. **Committed vs local-only** (this extends the old `.gitignore` fork, not a
    separate step). Ask once whether `.yoke/` is **committed** (Recommended — the
    team shares one flow map) or **local-only** (private to this machine). Record
    the answer in flow.md's Artifacts section. On **local-only**, append a
    `.yoke/` line to `.gitignore`.
+
+**Repos as an index (ADR-0010).** Write each linked repo's entry with its role,
+checkout path, and a one-line description — enough for an agent to orient
+without opening the neighbor. Never copy a linked repo's own operational facts:
+a library's publish command and consumers list live in the library's own
+flow.md (the fact owner), and this repo's entry points at it. Only when the
+linked checkout carries no flow.md do publish/consumers stay inline here.
 
 Write `.yoke/flow.md` with the resolved Repos, Tracker, and Artifacts sections
 (omit any section the project does not need — omission means "apply the
@@ -302,15 +367,16 @@ Show the user:
 
 ### User choice
 
-AskUserQuestion with 3 options:
+AskUserQuestion with 4 options:
 
-1. **Commit (Recommended)** — commit the artifacts and finish.
-2. **Review and edit** — the user edits files manually, then re-verify → return to Confirm.
-3. **Cancel** — do not commit, exit.
+1. **Commit and push (Recommended)** — commit the artifacts, push, and finish.
+2. **Commit only** — commit, leave the push to the user.
+3. **Review and edit** — the user edits files manually, then re-verify → return to Confirm.
+4. **Cancel** — do not commit, exit.
 
 **Handling:**
 
-- **Commit** → transition to Phase 7.
+- **Commit and push / Commit only** → transition to Phase 7, remembering the push choice.
 - **Review and edit** → wait for the user's signal, re-dispatch bootstrap-verifier, return to Confirm.
 - **Cancel** → tell the user "Bootstrap cancelled. CLAUDE.md, `.yoke/yoke-context.md`, and `.yoke/flow.md` remain on disk." Exit.
 
@@ -319,6 +385,17 @@ Mark in TodoWrite: `[x] Confirm`. Transition → Phase 7.
 ---
 
 ## Phase 7 — Commit
+
+### Branch check (before staging)
+
+Compare the current branch with the repo's default
+(`git symbolic-ref --short refs/remotes/origin/HEAD`). When they differ — or the
+flow map declares a cascade whose entry branch is not the current one — one
+AskUserQuestion: commit here (Recommended when the current branch is the
+cascade's entry point) or switch to the right branch first. Never land the
+artifacts on a branch the repo's flow will not pick up (observed: a commit to
+`master` in a `develop → staging → master` repo cost a separate back-merge
+tail).
 
 ### Stage and commit
 
@@ -339,6 +416,16 @@ git commit -m "chore: bootstrap yoke flow (local-only .yoke/)"
 
 On `index.lock` contention, wait 1–2s and retry.
 
+### Push
+
+When the user chose **Commit and push** in Phase 6:
+
+```bash
+git push -u origin "$(git branch --show-current)"
+```
+
+On **Commit only**, skip — but say in the summary that the commit is not pushed.
+
 ### Notification
 
 ```bash
@@ -351,7 +438,7 @@ Show:
 
 - Commit hash (from `git log -1 --format=%h`).
 - Paths to files: `CLAUDE.md`, `.yoke/yoke-context.md`, `.yoke/flow.md`, `.yoke/` (context.md, journal.md, ai/, adr/).
-- Artifacts mode: committed or local-only.
+- Artifacts mode: committed or local-only. Push state: pushed or left local.
 - Next step: "The project is ready to work with yoke. Try `/yoke:do` to start the first change."
 
 Mark in TodoWrite: `[x] Commit`.

--- a/skills/bootstrap/reference/flow-md.md
+++ b/skills/bootstrap/reference/flow-md.md
@@ -27,6 +27,12 @@ List every linked repo as a bullet with three fields:
 - **path** — checkout path (repository root, or `.` for the current repo).
 - **finish policy** — `pr` or `direct-push`.
 
+An optional fourth field makes the section double as an index of the org's
+neighbors (ADR-0010):
+
+- **description** — one line saying what the repo is, so an agent landing here
+  orients without opening the neighbor.
+
 `pr` finishes by branch → push → pull request (the default). `direct-push`
 finishes by committing to the repo's default branch, then **publishing the
 package and bumping its version in the consumer repos**. A `direct-push` repo
@@ -34,6 +40,16 @@ therefore adds two fields:
 
 - **publish** — the shell command that publishes the package (e.g. `npm publish`).
 - **consumers** — the repos whose dependency version `do` bumps after publish.
+
+**Fact ownership (ADR-0010).** A linked repo's operational details — its publish
+command, consumers list, its own cascade — live in **that repo's own flow.md**,
+the fact owner, not in every flow.md that mentions it. A consumer's entry for a
+library carries role, path, and description; skills resolve publish/consumers by
+reading the flow map at the library's `path`
+(`bash lib/flow-read.sh <path>`). Inline `publish:`/`consumers:` fields on a
+consumer's entry stay valid as an override for a linked checkout that carries no
+flow.md of its own. Duplicating an owner's facts is how three versions of one
+publish command end up across an org — link, don't copy.
 
 ### Branch cascade
 
@@ -72,31 +88,33 @@ Optional overrides of the shared conventions — currently one field:
 Skills must **never fail or nag** when `.yoke/flow.md`, or any field in it, is
 missing. A missing file or field degrades to its default:
 
-| Missing          | Behaves as                                                                                                |
-| ---------------- | --------------------------------------------------------------------------------------------------------- |
-| The whole file   | Single repo (current checkout), `pr` finish, no cascade, no deploy, no tracker steps, committed artifacts |
-| Repos section    | Single repo — the current checkout, role `app`, finish `pr`                                               |
-| Finish policy    | `pr`                                                                                                      |
-| Branch cascade   | No cascade — finish on the single default branch                                                          |
-| Deploy / release | No commands run                                                                                           |
-| Tracker          | No ticket comment, no ticket transition                                                                   |
-| Artifacts        | `committed`                                                                                               |
+| Missing                                          | Behaves as                                                                                                |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| The whole file                                   | Single repo (current checkout), `pr` finish, no cascade, no deploy, no tracker steps, committed artifacts |
+| Repos section                                    | Single repo — the current checkout, role `app`, finish `pr`                                               |
+| Finish policy                                    | `pr`                                                                                                      |
+| publish/consumers on a linked `direct-push` repo | Resolve from the flow map at that repo's `path` (the fact owner); nothing there either → no publish step  |
+| Branch cascade                                   | No cascade — finish on the single default branch                                                          |
+| Deploy / release                                 | No commands run                                                                                           |
+| Tracker                                          | No ticket comment, no ticket transition                                                                   |
+| Artifacts                                        | `committed`                                                                                               |
 
 ## Fields
 
-| Field                   | Values                              | Default          | Consumed by           |
-| ----------------------- | ----------------------------------- | ---------------- | --------------------- |
-| repo role               | `app` \| `library`                  | `app`            | `do`                  |
-| repo path               | checkout path                       | current checkout | `do`, `merge`         |
-| finish policy           | `pr` \| `direct-push`               | `pr`             | `do`                  |
-| publish (direct-push)   | shell command                       | —                | `do`                  |
-| consumers (direct-push) | repo names                          | —                | `do`                  |
-| branch cascade          | ordered branch chain + step command | none             | `merge`, `pr`         |
-| deploy / release        | shell commands                      | none             | `merge`               |
-| tracker                 | `github` \| `youtrack` \| `none`    | `none`           | `do`, `merge`         |
-| tracker target state    | state name                          | —                | `merge`               |
-| commit language         | language name                       | English          | `gca`, `do`           |
-| artifacts               | `committed` \| `local-only`         | `committed`      | bootstrap, all skills |
+| Field                   | Values                                 | Default          | Consumed by           |
+| ----------------------- | -------------------------------------- | ---------------- | --------------------- |
+| repo role               | `app` \| `library`                     | `app`            | `do`                  |
+| repo path               | checkout path                          | current checkout | `do`, `merge`         |
+| repo description        | one line                               | —                | agents (orientation)  |
+| finish policy           | `pr` \| `direct-push`                  | `pr`             | `do`                  |
+| publish (direct-push)   | shell command — in the owner's flow.md | —                | `do`                  |
+| consumers (direct-push) | repo names — in the owner's flow.md    | —                | `do`                  |
+| branch cascade          | ordered branch chain + step command    | none             | `merge`, `pr`         |
+| deploy / release        | shell commands                         | none             | `merge`               |
+| tracker                 | `github` \| `youtrack` \| `none`       | `none`           | `do`, `merge`         |
+| tracker target state    | state name                             | —                | `merge`               |
+| commit language         | language name                          | English          | `gca`, `do`           |
+| artifacts               | `committed` \| `local-only`            | `committed`      | bootstrap, all skills |
 
 ## Examples
 
@@ -120,19 +138,22 @@ committed
 
 ### Multi-repo: app + npm library
 
-App finishes via PR; the ui-kit library finishes via direct push to `master`,
-`npm publish`, and a version bump in the app. YouTrack tracker, `master → staging`
-cascade.
+App finishes via PR; the ui-kit library finishes via direct push, publish, and a
+version bump in its consumers. YouTrack tracker, `master → staging` cascade.
+The app's flow.md indexes the library and points at its fact owner; the publish
+command and consumers live only in the library's own flow.md.
+
+The app's `.yoke/flow.md`:
 
 ```md
 # Flow
 
 ## Repos
 
-- **app** — role: app, path: ~/organization/velvetnet/app, finish: pr
+- **app** — role: app, path: ., finish: pr
+  The org's customer-facing subscription app.
 - **ui-kit** — role: library, path: ~/organization/velvetnet/ui-kit, finish: direct-push
-  - publish: `npm publish`
-  - consumers: app
+  The org's shared UI kit; publish procedure and consumers — see its own `.yoke/flow.md`.
 
 ## Branch cascade
 
@@ -143,6 +164,27 @@ master → staging
 ## Deploy / release commands
 
 - Deploy app: `ssh deploy@app 'cd /srv/app && git pull && pnpm i && pm2 restart app'`
+
+## Tracker
+
+youtrack, target state: Done
+
+## Artifacts
+
+committed
+```
+
+The ui-kit's own `.yoke/flow.md` (the fact owner):
+
+```md
+# Flow
+
+## Repos
+
+- **ui-kit** — role: library, path: ., finish: direct-push
+  The org's shared UI kit, published to GitHub Packages.
+  - publish: `npm publish`
+  - consumers: app
 
 ## Tracker
 

--- a/skills/do/reference/finish.md
+++ b/skills/do/reference/finish.md
@@ -67,6 +67,16 @@ After implementation and per-task commits, finish each repo by its `finish` poli
   `consumers` — as part of that consumer's own change set (i.e. inside the
   consumer's branch and PR, not a stray commit).
 
+  When the flow map's entry for the repo carries no `publish`/`consumers` (the
+  entry only links to the repo as its fact owner, ADR-0010), resolve them from
+  the repo's own flow map:
+
+  ```bash
+  bash ${CLAUDE_PLUGIN_ROOT}/lib/flow-read.sh <repo-path>
+  ```
+
+  Nothing declared there either → push only, no publish step.
+
 ---
 
 ## 4. Multi-repo orchestration


### PR DESCRIPTION
## What

Bootstrap becomes cross-repo aware (ADR-0010). Running it across six same-org React projects showed the real cost of repo-blind onboarding is **drift, not tokens**: the ui-kit publish command was recorded three different ways across four flow.md files, ticket target-state diverged (Review vs Staging), consumers lists were mutually exclusive, and one session wrote a wrong tracker conclusion into flow.md that three parallel sibling sessions disproved. A re-bootstrap cost ~528k subagent tokens for a +37/−42 diff.

## How

- **Sibling discovery (Phase 0c).** `additionalDirectories` in `.claude/settings.local.json` is the only discovery signal — when it names an org dir or specific checkouts, that IS the declaration the repos belong together. No new org-level artifact; without the setting, behavior is unchanged.
- **Hypothesis + verify (Phase 1).** A stack-matching sibling's `yoke-context.md` (or the repo's own on a re-run — same mechanism makes re-bootstrap cheap) is passed to detect agents as a hypothesis; they verify each claim against the code and mark fields CONFIRMED/CHANGED. Unverified claims never reach the artifacts, so sibling drift is not inherited.
- **Flow pre-fill (Phase 5).** The sibling's flow.md collapses the interview into one confirmation; tracker options come from the real state schema (YouTrack `get_issue_fields_schema` / sibling), never invented Done/Fixed/Closed.
- **Repos as an index + fact owner (flow-md.md).** Each linked repo's entry: role, path, one-line description, pointer to its `.yoke/`. Publish/consumers live only in the library's own flow.md; `do` resolves them through the owner (`finish.md` §3). Links, not copies.
- **Side fixes from the session logs:** verifier gates on non-empty ISSUES at any grade (Grade A masked a real env-docs error), treats `.yoke/flow.md` forward references as valid (phase order), and never re-runs builds validation-scanner already ran (−3 min); Phase 7 checks the branch against the cascade before committing (a commit to `master` in a `develop→staging→master` repo cost a back-merge tail) and offers push in the confirm gate (all 4 observed sessions pushed manually); glossary seeding drops placeholder stubs and encyclopedia ballast.

## Notes

- `lib/flow-read.sh` needs no changes: description lines in Repos are non-bullet continuations the parser already ignores, and inline publish/consumers keep working as an override.
- Docs catalog (site/, README) intentionally not regenerated here — the working tree carries an unrelated in-progress docs pass; `/sync-docs` can follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtkDxh7WGuWCBQxeMBR8iE